### PR TITLE
Fix .gitlab-ci.yml curl command

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,9 @@ stages:
 review-job: # This job runs in the review stage, which runs first.
   stage: review
   script:
-    - curl -o dist.tar.gz https://github.com/maybeLab/openai-mr-reviewer-gltlab/releases/download/v1.0.0/dist.tar.gz && tar -vxzf dist.tar.gz && node dist/index.cjs
+    - curl -L https://github.com/maybeLab/openai-mr-reviewer-gltlab/releases/download/v1.0.0/dist.tar.gz > dist.tar.gz
+    - tar -vxzf dist.tar.gz
+    - node dist/index.cjs
     - echo "review complete."
     - rm -rf ./dist ./dist.tar.gz
   only:


### PR DESCRIPTION
I was having trouble with the provided curl command in the gitlab-ci.yml file. It did not seem to be correctly downloading the release artifact. I fixed the curl command by using the `-L` flag and outputting to the file.

Heres the gitlab error i was getting for reference
![image](https://github.com/maybeLab/openai-mr-reviewer-gltlab/assets/71405412/42f52278-11d2-4d3d-9bec-a7b176c430a4)
